### PR TITLE
cruft update: Add TestGetUrl

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/iterative/cookiecutter-dvc-plugin",
-  "commit": "825ad46a5fdd5cfb92f4993cad2ac6a6d1b0b971",
+  "commit": "7b38e245b247bee0a87ced7307f8f72d6ccef267",
   "checkout": null,
   "context": {
     "cookiecutter": {

--- a/dvc_azure/tests/cloud.py
+++ b/dvc_azure/tests/cloud.py
@@ -53,7 +53,11 @@ class Azure(Cloud, CloudURLInfo):
         raise NotImplementedError
 
     def is_dir(self):
-        raise NotImplementedError
+        path = self.path.rstrip("/") + "/"
+        cc = self.service_client.get_container_client(self.bucket)
+        for _ in cc.list_blobs(name_starts_with=path):
+            return True
+        return False
 
     def exists(self):
         raise NotImplementedError

--- a/dvc_azure/tests/test_dvc.py
+++ b/dvc_azure/tests/test_dvc.py
@@ -5,8 +5,13 @@ from dvc.testing.api_tests import (  # noqa, pylint: disable=unused-import
 from dvc.testing.remote_tests import (  # noqa, pylint: disable=unused-import
     TestRemote,
 )
+from dvc.testing.workspace_tests import (  # noqa, pylint: disable=unused-import
+    TestGetUrl,
+)
 from dvc.testing.workspace_tests import TestImport as _TestImport
-from dvc.testing.workspace_tests import TestLsUrl as _TestLsUrl
+from dvc.testing.workspace_tests import (  # noqa, pylint: disable=unused-import
+    TestLsUrl,
+)
 
 
 @pytest.fixture
@@ -39,7 +44,3 @@ class TestImport(_TestImport):
     @pytest.fixture
     def dir_md5(self):
         return "ec602a6ba97b2dd07bd6d2cd89674a60.dir"
-
-
-class TestLsUrl(_TestLsUrl):
-    pass


### PR DESCRIPTION
Add `dvc get-url` tests, and implement `Azure.is_dir()`, which is used by TestLsUrl and TestGetUrl.