### PR TITLE
rm: Ensure `expand_path=False`.

### DIFF
--- a/dvc_azure/__init__.py
+++ b/dvc_azure/__init__.py
@@ -178,3 +178,7 @@ class AzureFileSystem(ObjectFileSystem):
     def put_file(self, *args, **kwargs) -> None:
         kwargs["overwrite"] = True
         super().put_file(*args, **kwargs)
+
+    def rm(self, *args, **kwargs) -> None:
+        kwargs["expand_path"] = False
+        super().rm(*args, **kwargs)


### PR DESCRIPTION
To fix https://github.com/iterative/dvc/issues/8868 but also for performance reasons (https://github.com/fsspec/adlfs/pull/383)