### PR TITLE
spec: Wrap public methods.

### DIFF
--- a/dvc_azure/spec.py
+++ b/dvc_azure/spec.py
@@ -4,10 +4,10 @@ from adlfs import AzureBlobFileSystem as _AzureBlobFileSystem
 class AzureBlobFileSystem(  # pylint: disable=abstract-method
     _AzureBlobFileSystem
 ):
-    async def _put_file(self, *args, **kwargs) -> None:
+    def put_file(self, *args, **kwargs) -> None:
         kwargs["overwrite"] = True
-        return await super()._put_file(*args, **kwargs)
+        return super().put_file(*args, **kwargs)
 
-    async def _rm(self, *args, **kwargs) -> None:
+    def rm(self, *args, **kwargs) -> None:
         kwargs["expand_path"] = False
-        return await super()._rm(*args, **kwargs)
+        return super().rm(*args, **kwargs)


### PR DESCRIPTION
The wrapping of the private async methods was not working as expected.

In dvc-http, the wrapping was working because the implementation doesn't use `sync_wrapper`, but it in adlfs we need to do it this way:

https://github.com/fsspec/adlfs/blob/71c068458390192a4753e7127ba9c244eec59697/adlfs/spec.py#L1619

For https://github.com/iterative/dvc/issues/9506