### PR TITLE
spec: wrap async and sync overridden adlfs methods

### DIFF
--- a/dvc_azure/spec.py
+++ b/dvc_azure/spec.py
@@ -8,6 +8,14 @@ class AzureBlobFileSystem(  # pylint: disable=abstract-method
         kwargs["overwrite"] = True
         return super().put_file(*args, **kwargs)
 
+    async def _put_file(self, *args, **kwargs) -> None:
+        kwargs["overwrite"] = True
+        return await super()._put_file(*args, **kwargs)
+
     def rm(self, *args, **kwargs) -> None:
         kwargs["expand_path"] = False
         return super().rm(*args, **kwargs)
+
+    async def _rm(self, *args, **kwargs) -> None:
+        kwargs["expand_path"] = False
+        return await super()._rm(*args, **kwargs)


### PR DESCRIPTION
Closes https://github.com/iterative/dvc-azure/issues/50

We can also remove the put_file override in the future if this upstream PR gets merged: https://github.com/fsspec/adlfs/pull/419